### PR TITLE
merge: update to helium-chromium 138.0.7204.49

### DIFF
--- a/.github/actions/prepare-environment/action.yml
+++ b/.github/actions/prepare-environment/action.yml
@@ -3,10 +3,10 @@ runs:
   using: composite
   steps:
     - name: Cleanup Xcode installations
-      run: sudo mv /Applications/Xcode_16.app /Applications/tmp_Xcode_16.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_Xcode_16.app /Applications/Xcode_16.app
+      run: sudo mv /Applications/Xcode_16.4.app /Applications/tmp_Xcode_16.4.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_Xcode_16.4.app /Applications/Xcode_16.4.app
       shell: bash
     - name: Select Xcode version
-      run: sudo xcode-select --switch /Applications/Xcode_16.app
+      run: sudo xcode-select --switch /Applications/Xcode_16.4.app
       shell: bash
     - name: Cleanup Xcode Simulators
       run: sudo xcrun simctl delete all
@@ -21,7 +21,7 @@ runs:
       run: sudo mdutil -a -i off
       shell: bash
     - name: Run xcode-select
-      run: sudo xcode-select --switch /Applications/Xcode_16.app
+      run: sudo xcode-select --switch /Applications/Xcode_16.4.app
       shell: bash
     - name: Setup Environment and Toolchain
       run: ./github_setup_env_toolchain.sh ${{ inputs.arch }} | tee -a github_actions_setup_env_toolchain.log

--- a/.github/scripts/github_build.sh
+++ b/.github/scripts/github_build.sh
@@ -16,8 +16,6 @@ fi
 
 cd "$_src_dir"
 
-ln -s "$_src_dir/third_party" "$_src_dir/../third_party"
-
 echo $(date +%s) | tee -a "$_root_dir/build_times_$_target_cpu.log"
 echo "status=running" >> $GITHUB_OUTPUT
 

--- a/README.md
+++ b/README.md
@@ -104,19 +104,19 @@ Once it's complete, a `.dmg` should appear in `build/`.
     ```
 
 3. Update Rust toolchain (if necessary)
-    1. Check the `RUST_VERSION` constant in file `src/tools/rust/update_rust.py` in build root.
-        * As an example, the revision as of writing this guide is `340bb19fea20fd5f9357bbfac542fad84fc7ea2b`.
+    1. Check the `RUST_REVISION` constant in file `src/tools/rust/update_rust.py` in build root.
+        * As an example, the revision as of writing this guide is `4a0969e06dbeaaa43914d2d00b2e843d49aa3886`.
     2. Get date for nightly Rust build from Rust's GitHub repository.
-        * The page URL for our example is `https://github.com/rust-lang/rust/commit/340bb19fea20fd5f9357bbfac542fad84fc7ea2b`
-            1. In this case, the corresponding nightly build date is `2024-02-14`.
-            2. Adapt the version number in `downloads-arm64.ini` and `downloads-x86_64.ini` accordingly.
+        * The page URL for our example is `https://github.com/rust-lang/rust/commit/4a0969e06dbeaaa43914d2d00b2e843d49aa3886`
+            1. In this case, the corresponding nightly build date is `2024-05-05`.
+            2. Adapt the version number in `downloads-{arm64,x86-64}{,-rustlib}.ini` accordingly.
     3. Get the information of the latest nightly build and adapt configurations accordingly.
        1. Download the latest nightly build from the Rust website.
-            * For our example, the download URL for Apple Silicon Macs is `https://static.rust-lang.org/dist/2024-02-14/rust-nightly-aarch64-apple-darwin.tar.gz`
-            * For our example, the download URL for Intel Chip Macs is `https://static.rust-lang.org/dist/2024-02-14/rust-nightly-x86_64-apple-darwin.tar.gz`
+            * For our example, the download URL for Apple Silicon Macs is `https://static.rust-lang.org/dist/2024-05-05/rust-nightly-aarch64-apple-darwin.tar.gz`
+            * For our example, the download URL for Intel Chip Macs is `https://static.rust-lang.org/dist/2024-05-05/rust-nightly-x86_64-apple-darwin.tar.gz`
        2. Extract the archive.
        3. Execute `rustc/bin/rustc -V` in the extracted directory to get Rust version string.
-            * For our example, the version string is `rustc 1.78.0-nightly (a84bb95a1 2024-02-13)`.
+            * For our example, the version string is `rustc 1.88.0-nightly (13e879094 2025-05-04)`.
        4. Adapt the content of `retrieve_and_unpack_resource.sh` and `patches/ungoogled-chromium/macos/fix-build-with-rust.patch` accordingly.
 4. Switch to src directory
 

--- a/build.sh
+++ b/build.sh
@@ -79,8 +79,6 @@ cd "$_src_dir"
 
 ./out/Default/gn gen out/Default --fail-on-unused-args
 
-ln -s "$_src_dir/third_party" "$_src_dir/../third_party"
-
 ninja -C out/Default chrome chromedriver
 
 "$_root_dir/sign_and_package_app.sh"

--- a/dev.sh
+++ b/dev.sh
@@ -36,7 +36,6 @@ ___helium_info_pull() {
 ___helium_info_pull_thirdparty() {
     mkdir -p "$_src_dir/third_party/llvm-build/Release+Asserts"
     mkdir -p "$_src_dir/third_party/rust-toolchain/bin"
-    ln -s "$_src_dir/third_party" "$_root_dir/build/third_party"
 
     "$_root_dir/retrieve_and_unpack_resource.sh" -p
 }

--- a/downloads-arm64-rustlib.ini
+++ b/downloads-arm64-rustlib.ini
@@ -1,5 +1,5 @@
 [rustlib-arm64]
-version = 2025-02-15
+version = 2025-05-05
 url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-aarch64-apple-darwin.tar.xz
 download_filename = rust-nightly-%(version)s-aarch64-apple-darwin.tar.xz
 output_path = third_party/rust-toolchain/rustc/lib/rustlib

--- a/downloads-arm64.ini
+++ b/downloads-arm64.ini
@@ -18,7 +18,7 @@ sha512 = 1ba7ec05c1445c03d561cc9acc50d64446bf71ae54c657fecb2ee1cfaa3739906ee8e01
 output_path = third_party/node/mac_arm64/node-darwin-arm64
 
 [rust]
-version = 2025-02-15
+version = 2025-05-05
 url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-aarch64-apple-darwin.tar.xz
 download_filename = rust-nightly-%(version)s-aarch64-apple-darwin.tar.xz
 output_path = third_party/rust-toolchain

--- a/downloads-x86-64-rustlib.ini
+++ b/downloads-x86-64-rustlib.ini
@@ -1,5 +1,5 @@
 [rustlib-x86-64]
-version = 2025-02-15
+version = 2025-05-05
 url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-x86_64-apple-darwin.tar.xz
 download_filename = rust-nightly-%(version)s-x86_64-apple-darwin.tar.xz
 output_path = third_party/rust-toolchain/rustc/lib/rustlib

--- a/downloads-x86-64.ini
+++ b/downloads-x86-64.ini
@@ -18,7 +18,7 @@ sha512 = 0fdd6978268f8f7f6d3dd2a4f965eb7dbf0a4e0d5560fa7f6da58a65b7b75ab51ac209b
 output_path = third_party/node/mac/node-darwin-x64
 
 [rust]
-version = 2025-02-15
+version = 2025-05-05
 url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-x86_64-apple-darwin.tar.xz
 download_filename = rust-nightly-%(version)s-x86_64-apple-darwin.tar.xz
 output_path = third_party/rust-toolchain

--- a/patches/helium/macos/change-keychain-name.patch
+++ b/patches/helium/macos/change-keychain-name.patch
@@ -1,6 +1,6 @@
 --- a/components/os_crypt/sync/keychain_password_mac.mm
 +++ b/components/os_crypt/sync/keychain_password_mac.mm
-@@ -29,13 +29,8 @@ namespace {
+@@ -30,13 +30,8 @@ namespace {
  // These two strings ARE indeed user facing.  But they are used to access
  // the encryption keyword.  So as to not lose encrypted data when system
  // locale changes we DO NOT LOCALIZE.
@@ -14,5 +14,5 @@
 +const char kDefaultServiceName[] = "Helium Storage Key";
 +const char kDefaultAccountName[] = "Helium";
  
- // Generates a random password and adds it to the Keychain.  The added password
- // is returned from the function.  If an error occurs, an empty password is
+ // These values are persisted to logs. Entries should not be renumbered and
+ // numeric values should never be reused.

--- a/patches/helium/macos/rust-dep.patch
+++ b/patches/helium/macos/rust-dep.patch
@@ -1,6 +1,6 @@
 --- a/services/webnn/BUILD.gn
 +++ b/services/webnn/BUILD.gn
-@@ -117,6 +117,7 @@ component("webnn_service") {
+@@ -129,6 +129,7 @@ component("webnn_service") {
      deps += [
        "//third_party/coremltools:modelformat_proto",
        "//third_party/fp16",

--- a/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
+++ b/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
@@ -1,6 +1,6 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1634,8 +1634,7 @@ config("compiler_deterministic") {
+@@ -1683,8 +1683,7 @@ config("compiler_deterministic") {
  }
  
  config("clang_revision") {

--- a/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
+++ b/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -1249,7 +1249,7 @@ if (is_win) {
+@@ -1251,7 +1251,7 @@ if (is_win) {
  
    # TOOD(crbug/1163903#c8) - thakis@ look into why profile and coverage
    # instrumentation adds these symbols in different orders

--- a/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
+++ b/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
@@ -1,6 +1,6 @@
 --- a/build/config/clang/BUILD.gn
 +++ b/build/config/clang/BUILD.gn
-@@ -276,8 +276,6 @@ clang_lib("compiler_builtins") {
+@@ -287,8 +287,6 @@ clang_lib("compiler_builtins") {
      } else {
        assert(false, "unsupported target_platform=$target_platform")
      }
@@ -11,24 +11,21 @@
  
 --- a/build/config/rust.gni
 +++ b/build/config/rust.gni
-@@ -59,17 +59,17 @@ declare_args() {
+@@ -52,7 +52,7 @@ declare_args() {
    # To use a custom toolchain instead, specify an absolute path to the root of
    # a Rust sysroot, which will have a 'bin' directory and others. Commonly
    # <home dir>/.rustup/toolchains/nightly-<something>-<something>
 -  rust_sysroot_absolute = ""
-+  rust_sysroot_absolute = "../../third_party/rust-toolchain"
++  rust_sysroot_absolute = "//third_party/rust-toolchain"
  
    # Directory under which to find `bin/bindgen` (a `bin` directory containing
    # the bindgen exectuable).
--  rust_bindgen_root = "//third_party/rust-toolchain"
-+  rust_bindgen_root = "../../third_party/rust-toolchain"
- 
-   # If you're using a Rust toolchain as specified by rust_sysroot_absolute,
+@@ -62,7 +62,7 @@ declare_args() {
    # set this to the output of `rustc -V`. Changing this string will cause all
    # Rust targets to be rebuilt, which allows you to update your toolchain and
    # not break incremental builds.
 -  rustc_version = ""
-+  rustc_version = "rustc 1.86.0-nightly (69fd5e405 2025-02-15)"
++  rustc_version = "rustc 1.88.0-nightly (13e879094 2025-05-04)"
  
    # If you're using a Rust toolchain as specified by rust_sysroot_absolute,
    # you can specify whether it supports nacl here.

--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -13,7 +13,7 @@
      "//chrome/browser/search",
      "//chrome/browser/search_engine_choice:impl",
      "//chrome/browser/signin:impl",
-@@ -1966,7 +1962,6 @@ static_library("browser") {
+@@ -1986,7 +1982,6 @@ static_library("browser") {
      "//chrome/browser/reading_list",
      "//chrome/browser/resource_coordinator:tab_manager_features",
      "//chrome/browser/resources/accessibility:resources",
@@ -23,7 +23,7 @@
      "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
 --- a/chrome/browser/extensions/BUILD.gn
 +++ b/chrome/browser/extensions/BUILD.gn
-@@ -777,9 +777,6 @@ source_set("extensions") {
+@@ -792,9 +792,6 @@ source_set("extensions") {
        # TODO(crbug.com/346472679): Remove this circular dependency.
        "//chrome/browser/web_applications/extensions",
  
@@ -33,18 +33,18 @@
        # TODO(crbug.com/343037853): Remove this circular dependency.
        "//chrome/browser/themes",
  
-@@ -815,7 +812,6 @@ source_set("extensions") {
+@@ -830,7 +827,6 @@ source_set("extensions") {
        "//chrome/common",
        "//chrome/common/extensions/api",
        "//components/omnibox/browser",
 -      "//components/safe_browsing/core/common/proto:csd_proto",
        "//components/safe_browsing/core/common/proto:realtimeapi_proto",
-       "//components/signin/core/browser",
        "//components/translate/content/browser",
+       "//content/public/browser",
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
-@@ -586,17 +586,8 @@ static_library("ui") {
-     "//components/reading_list/features:flags",
+@@ -562,17 +562,8 @@ static_library("ui") {
+     "//components/reading_list/core",
      "//components/renderer_context_menu",
      "//components/resources",
 -    "//components/safe_browsing/content/browser",
@@ -59,9 +59,9 @@
      "//components/safe_browsing/core/common/hashprefix_realtime:hash_realtime_utils",
 -    "//components/safe_browsing/core/common/proto:csd_proto",
      "//components/schema_org/common:improved_mojom",
-     "//components/search",
      "//components/search_engines",
-@@ -5771,7 +5762,6 @@ static_library("ui_public_dependencies")
+     "//components/security_interstitials/content:security_interstitial_page",
+@@ -5731,7 +5722,6 @@ static_library("ui_public_dependencies")
      "//components/dom_distiller/core",
      "//components/enterprise/buildflags",
      "//components/paint_preview/buildflags",
@@ -162,7 +162,7 @@
      case download::DOWNLOAD_DANGER_TYPE_DANGEROUS_HOST:
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
-@@ -7295,13 +7295,9 @@ test("unit_tests") {
+@@ -7349,13 +7349,9 @@ test("unit_tests") {
        "//chrome/browser/renderer_host:history_swiper",
        "//chrome/browser/updater:browser_updater_client",
        "//chrome/common/notifications",
@@ -191,7 +191,7 @@
        "safe_archive_analyzer.cc",
 --- a/chrome/browser/policy/configuration_policy_handler_list_factory.cc
 +++ b/chrome/browser/policy/configuration_policy_handler_list_factory.cc
-@@ -2311,15 +2311,6 @@ const PolicyToPreferenceMapEntry kSimple
+@@ -2296,15 +2296,6 @@ const PolicyToPreferenceMapEntry kSimple
      base::Value::Type::BOOLEAN },
  #endif
  
@@ -209,7 +209,7 @@
      lens::prefs::kLensOverlaySettings,
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
-@@ -8113,33 +8113,6 @@ bool ChromeContentBrowserClient::SetupEm
+@@ -7691,33 +7691,6 @@ bool ChromeContentBrowserClient::SetupEm
      CHECK(!soda_language_pack_path.empty());
      CHECK(serializer->SetParameter(sandbox::policy::kParamSodaLanguagePackPath,
                                     soda_language_pack_path.value()));

--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -23,7 +23,7 @@
      "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
 --- a/chrome/browser/extensions/BUILD.gn
 +++ b/chrome/browser/extensions/BUILD.gn
-@@ -792,9 +792,6 @@ source_set("extensions") {
+@@ -793,9 +793,6 @@ source_set("extensions") {
        # TODO(crbug.com/346472679): Remove this circular dependency.
        "//chrome/browser/web_applications/extensions",
  
@@ -33,7 +33,7 @@
        # TODO(crbug.com/343037853): Remove this circular dependency.
        "//chrome/browser/themes",
  
-@@ -830,7 +827,6 @@ source_set("extensions") {
+@@ -831,7 +828,6 @@ source_set("extensions") {
        "//chrome/common",
        "//chrome/common/extensions/api",
        "//components/omnibox/browser",
@@ -43,7 +43,7 @@
        "//content/public/browser",
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
-@@ -562,17 +562,8 @@ static_library("ui") {
+@@ -566,17 +566,8 @@ static_library("ui") {
      "//components/reading_list/core",
      "//components/renderer_context_menu",
      "//components/resources",
@@ -61,7 +61,7 @@
      "//components/schema_org/common:improved_mojom",
      "//components/search_engines",
      "//components/security_interstitials/content:security_interstitial_page",
-@@ -5731,7 +5722,6 @@ static_library("ui_public_dependencies")
+@@ -5746,7 +5737,6 @@ static_library("ui_public_dependencies")
      "//components/dom_distiller/core",
      "//components/enterprise/buildflags",
      "//components/paint_preview/buildflags",

--- a/retrieve_and_unpack_resource.sh
+++ b/retrieve_and_unpack_resource.sh
@@ -100,7 +100,7 @@ if $retrieve_arch_specific; then
     _rustc_dir="$_rust_dir/rustc"
     _rustc_lib_dir="$_rust_dir/rustc/lib/rustlib/$_rust_name/lib"
 
-    echo "rustc 1.85.0-nightly (69fd5e405 2025-02-15)" > "$_rust_flag_file"
+    echo "rustc 1.88.0-nightly (13e879094 2025-05-04)" > "$_rust_flag_file"
 
     mkdir -p "$_rust_bin_dir"
     mkdir -p "$_rust_dir/lib"

--- a/sign_and_package_app.sh
+++ b/sign_and_package_app.sh
@@ -72,3 +72,7 @@ chrome/installer/mac/pkg-dmg \
   --target "$OUT_DMG_PATH" \
   --volname Helium --symlink /Applications:/Applications \
   --format UDBZ --verbosity 2
+
+if ! [ -z "${MACOS_CERTIFICATE_NAME-}" ]; then
+  codesign --sign "$MACOS_CERTIFICATE_NAME" --force "$OUT_DMG_PATH"
+fi


### PR DESCRIPTION
helium-chromium: https://github.com/imputnet/helium-chromium/pull/22

upstream changes:
> * Updated Rust to 2025-05-05.
> * Removed the `build/third_party` symlink, and pointed `rust_sysroot_absolute` directly to `//third_party/rust-toolchain` since the old solution no longer worked.
> * Removed `disable-clang-extend-variable-liveness.patch` since the block this was removing was removed upstream in [[6541127]](https://chromium-review.googlesource.com/c/chromium/src/+/6541127).

significant changes:
- bumped xcode version to 16.4 due to changes in [[6575804]](https://chromium-review.googlesource.com/c/chromium/src/+/6575804)
