### PR TITLE
ci/scripts: use a fixed version of httplib2

### DIFF
--- a/.github/scripts/github_setup_env_toolchain.sh
+++ b/.github/scripts/github_setup_env_toolchain.sh
@@ -9,4 +9,4 @@ if ! command -v sccache 2>&1 >/dev/null; then
 fi
 
 # Install Python dependencies from PyPI
-pip3 install httplib2 requests pillow --break-system-packages
+pip3 install httplib2==0.22.0 requests pillow --break-system-packages

--- a/.github/scripts/sanity-check.sh
+++ b/.github/scripts/sanity-check.sh
@@ -8,7 +8,7 @@ brew install ninja coreutils python@3.13 quilt llvm@20 --overwrite
 brew unlink python || true
 brew link python@3.13 llvm@20 --force
 
-pip3.13 install httplib2 requests Pillow --break
+pip3.13 install httplib2==0.22.0 requests Pillow --break
 
 source dev.sh
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ licensed under their [BSD 3-Clause license](LICENSE.ungoogled_chromium)).
 ### Setting up the build environment
 
 1. Install Python 3 via Homebrew: `brew install python@3`
-2. Install Python dependencies via `pip3`: `pip3 install httplib2 requests pillow`, note that you might need to use `--break-system-packages` if you don't want to use a dedicated Python environment for building Ungoogled-Chromium.
+2. Install Python dependencies via `pip3`: `pip3 install httplib2==0.22.0 requests pillow`, note that you might need to use `--break-system-packages` if you don't want to use a dedicated Python environment for building Ungoogled-Chromium.
 3. Install LLVM via Homebrew: `brew install llvm`, and set `LDFLAGS` and `CPPFLAGS` environment variables according to the Homebrew prompt.
 4. Install Ninja via Homebrew: `brew install ninja`
 5. Install GNU coreutils and readline via Homebrew: `brew install coreutils readline`


### PR DESCRIPTION
because socks in the latest version are currently broken and unusable for gclient