### PR TITLE
downloads: bump sparkle to 2.8.0

### DIFF
--- a/downloads.ini
+++ b/downloads.ini
@@ -14,9 +14,9 @@ sha512 = 18e1e8d91869f82c1b4582c60e191a6f946dd9958f1e1279d86259d45589fbceec636f7
 output_path = third_party/google_toolbox_for_mac/src
 
 [sparkle]
-version = 2.7.2
+version = 2.8.0
 url = https://github.com/sparkle-project/Sparkle/archive/refs/tags/%(version)s.tar.gz
-sha512 = 6d1cea3f04758d3674587c9b9beb29e47f8474f73aff70c09ef2dac3384712c9e90f4e55c6e50e64819480d39c20e880def4476f2defbaf101a303cb1499fee9
+sha512 = 1aff805c3c908e056d8ce2a0cbe4d4df55b07b492f621137b8a4d2a2d18339f5987a7f9dd5372a6ab012de33a96ae0d9fdb1ba1ec19ab123643051e16f8b85ce
 strip_leading_dirs = Sparkle-%(version)s
 download_filename = sparkle-v%(version)s.tar.gz
 output_path = third_party/sparkle

--- a/patches/helium/macos/updater/sparkle2-integration.patch
+++ b/patches/helium/macos/updater/sparkle2-integration.patch
@@ -201,27 +201,28 @@
      # Any circular includes must depend on the target "//chrome/browser:browser_public_dependencies".
 --- a/third_party/sparkle/Sparkle.xcodeproj/project.pbxproj
 +++ b/third_party/sparkle/Sparkle.xcodeproj/project.pbxproj
-@@ -454,6 +454,8 @@
+@@ -446,6 +446,8 @@
  		72F9EC441D5E9ED8004AC8B6 /* SPUDownloadData.h in Headers */ = {isa = PBXBuildFile; fileRef = 72F9EC421D5E9ED8004AC8B6 /* SPUDownloadData.h */; settings = {ATTRIBUTES = (Public, ); }; };
  		72F9EC451D5E9ED8004AC8B6 /* SPUDownloadData.m in Sources */ = {isa = PBXBuildFile; fileRef = 72F9EC431D5E9ED8004AC8B6 /* SPUDownloadData.m */; };
  		72F9EC481D5EA904004AC8B6 /* SPUUpdaterDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 72F9EC471D5EA7D3004AC8B6 /* SPUUpdaterDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 +		75709667053ACD97A7429E07 /* SPUHeadlessUserDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C9EE836A8449E0F363F7E47 /* SPUHeadlessUserDriver.h */; };
 +		9328EB08163BA45AD58F2AC8 /* SPUHeadlessUserDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = A444E1A92967D436041BC0FA /* SPUHeadlessUserDriver.m */; };
+ 		72FE54422E56A14100227A91 /* SUUpdateAlert.xib in Resources */ = {isa = PBXBuildFile; fileRef = 72FE54412E56A14100227A91 /* SUUpdateAlert.xib */; };
  		C23E885B1BE7B24F0050BB73 /* SparkleTestCodeSignApp.enc.dmg in Resources */ = {isa = PBXBuildFile; fileRef = C23E88591BE7AF890050BB73 /* SparkleTestCodeSignApp.enc.dmg */; };
  		EA1E281722B645AE004AA304 /* libbsdiff.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA1E280F22B64522004AA304 /* libbsdiff.a */; };
- 		EA1E281822B645CE004AA304 /* libbsdiff.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA1E280F22B64522004AA304 /* libbsdiff.a */; };
-@@ -1459,8 +1461,10 @@
+@@ -1381,9 +1383,11 @@
  		72F9EC421D5E9ED8004AC8B6 /* SPUDownloadData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPUDownloadData.h; sourceTree = "<group>"; };
  		72F9EC431D5E9ED8004AC8B6 /* SPUDownloadData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPUDownloadData.m; sourceTree = "<group>"; };
  		72F9EC471D5EA7D3004AC8B6 /* SPUUpdaterDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPUUpdaterDelegate.h; sourceTree = "<group>"; };
 +		7C9EE836A8449E0F363F7E47 /* SPUHeadlessUserDriver.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPUHeadlessUserDriver.h; sourceTree = "<group>"; };
+ 		72FE54412E56A14100227A91 /* SUUpdateAlert.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SUUpdateAlert.xib; sourceTree = "<group>"; };
  		8DC2EF5A0486A6940098B216 /* Sparkle-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Sparkle-Info.plist"; sourceTree = "<group>"; };
  		8DC2EF5B0486A6940098B216 /* Sparkle.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Sparkle.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 +		A444E1A92967D436041BC0FA /* SPUHeadlessUserDriver.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPUHeadlessUserDriver.m; sourceTree = "<group>"; };
  		A5BF4F1B1BC7668B007A052A /* SUTestWebServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUTestWebServer.h; sourceTree = "<group>"; };
  		A5BF4F1C1BC7668B007A052A /* SUTestWebServer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUTestWebServer.m; sourceTree = "<group>"; };
  		C23E88591BE7AF890050BB73 /* SparkleTestCodeSignApp.enc.dmg */ = {isa = PBXFileReference; lastKnownFileType = file; path = SparkleTestCodeSignApp.enc.dmg; sourceTree = "<group>"; };
-@@ -1724,7 +1728,7 @@
+@@ -1644,7 +1648,7 @@
  			name = Products;
  			sourceTree = "<group>";
  		};
@@ -230,7 +231,7 @@
  			isa = PBXGroup;
  			children = (
  				723DFF962B3DFF6E00628E6C /* Package.swift */,
-@@ -2090,7 +2094,6 @@
+@@ -2007,7 +2011,6 @@
  				72AEB1D629A1CB510033883E /* SPUNoUpdateFoundInfo.h */,
  				72AEB1D729A1CB510033883E /* SPUNoUpdateFoundInfo.m */,
  			);
@@ -238,7 +239,7 @@
  			name = "Other Sources";
  			sourceTree = "<group>";
  		};
-@@ -2293,6 +2296,8 @@
+@@ -2210,6 +2213,8 @@
  				7269E49C2648FC6C0088C213 /* SPUUserUpdateState+Private.h */,
  				7269E4992648F7C00088C213 /* SPUUserUpdateState.m */,
  				725CB9561C7120410064365A /* SPUUserDriver.h */,
@@ -247,7 +248,7 @@
  			);
  			name = "User Driver";
  			sourceTree = "<group>";
-@@ -2629,6 +2634,7 @@
+@@ -2545,6 +2550,7 @@
  				3772FEA913DE0B6B00F79537 /* SUVersionDisplayProtocol.h in Headers */,
  				724BB3871D32A167005D534A /* SUXPCInstallerConnection.h in Headers */,
  				724BB3A81D33461B005D534A /* SUXPCInstallerStatus.h in Headers */,
@@ -255,7 +256,7 @@
  			);
  			runOnlyForDeploymentPostprocessing = 0;
  		};
-@@ -3146,7 +3152,7 @@
+@@ -3062,7 +3068,7 @@
  				zh_HK,
  				nn,
  			);
@@ -264,7 +265,7 @@
  			packageReferences = (
  				727DBAE326B5BBFD00111F0C /* XCRemoteSwiftPackageReference "swift-argument-parser" */,
  			);
-@@ -3709,6 +3715,7 @@
+@@ -3620,6 +3626,7 @@
  				724BB3881D32A167005D534A /* SUXPCInstallerConnection.m in Sources */,
  				724BB3A91D33461B005D534A /* SUXPCInstallerStatus.m in Sources */,
  				723AC011259DBDAA00BDB4FA /* SUReleaseNotesCommon.m in Sources */,


### PR DESCRIPTION
https://github.com/sparkle-project/Sparkle/releases/tag/2.8.0