### PR TITLE
ci: prepare xcode 26 no matter the name, refactor

### DIFF
--- a/.github/actions/prepare-environment/action.yml
+++ b/.github/actions/prepare-environment/action.yml
@@ -2,26 +2,17 @@ name: Prepare build environment
 runs:
   using: composite
   steps:
-    - name: Cleanup Xcode installations
-      run: sudo mv /Applications/Xcode_26.0.app /Applications/tmp_Xcode_26.0.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_Xcode_26.0.app /Applications/Xcode_26.0.app
+    - name: Copy GitHub specific scripts to git-root folder
+      run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
       shell: bash
-    - name: Select Xcode version
-      run: sudo xcode-select --switch /Applications/Xcode_26.0.app
-      shell: bash
-    - name: Cleanup Xcode Simulators
-      run: sudo xcrun simctl delete all
+    - name: Prepare Xcode
+      run: ./github_prepare_xcode.sh
       shell: bash
     - name: Cleanup Android Related Stuff
       run: sudo rm -rf $ANDROID_HOME
       shell: bash
-    - name: Copy GitHub specific scripts to git-root folder
-      run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
-      shell: bash
     - name: Disable Spotlight
       run: sudo mdutil -a -i off
-      shell: bash
-    - name: Run xcode-select
-      run: sudo xcode-select --switch /Applications/Xcode_26.0.app
       shell: bash
     - name: Setup Environment and Toolchain
       run: ./github_setup_env_toolchain.sh ${{ inputs.arch }} | tee -a github_actions_setup_env_toolchain.log

--- a/.github/scripts/github_prepare_xcode.sh
+++ b/.github/scripts/github_prepare_xcode.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -eux
+
+set -o pipefail
+
+# Sometimes Xcode is 26.0, sometimes 26. We make sure it's usable no matter its name.
+BASE_XCODE_PATH=/Applications/Xcode_26.0.app
+TARGET_XCODE_PATH=/Applications/Xcode_26.app
+
+if [ ! -e "$BASE_XCODE_PATH" ] && [ ! -e "$TARGET_XCODE_PATH" ]; then
+  echo "Failed to find a suitable version of Xcode"
+  exit 1
+fi
+
+if [ -e "$BASE_XCODE_PATH" ] && [ ! -e "$TARGET_XCODE_PATH" ]; then
+  REAL_XCODE_PATH="$(readlink -f "$BASE_XCODE_PATH")"
+  sudo mv "$REAL_XCODE_PATH" "$TARGET_XCODE_PATH"
+fi
+
+# Cleanup any other Xcode versions
+sudo mv "$TARGET_XCODE_PATH" /Applications/tmp_Xcode_26.app
+sudo rm -rf /Applications/Xcode*
+sudo mv /Applications/tmp_Xcode_26.app "$TARGET_XCODE_PATH"
+
+# Switch to target Xcode and clean simulators
+sudo xcode-select --switch "$TARGET_XCODE_PATH"
+sudo xcrun simctl delete all

--- a/.github/scripts/sanity-check.sh
+++ b/.github/scripts/sanity-check.sh
@@ -2,7 +2,6 @@
 set -exo pipefail
 
 sudo mdutil -a -i off
-sudo xcode-select --switch /Applications/Xcode_26.0.app
 
 brew install ninja coreutils python@3.14 quilt llvm@20 --overwrite
 brew unlink python || true

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -12,8 +12,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Copy GitHub specific scripts to git-root folder
-      run: cp -va ./.github/scripts/ ./
+    - uses: ./.github/actions/prepare-environment
     - name: Run sanity check
       run: ./sanity-check.sh
   substitution:
@@ -22,7 +21,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Copy GitHub specific scripts to git-root folder
-      run: cp -va ./.github/scripts/ ./
+    - uses: ./.github/actions/prepare-environment
     - name: Run substitution check
       run: ./sanity-check.sh sub


### PR DESCRIPTION
now all xcode setup & cleanup stuff is handled by `.github/scripts/github_prepare_xcode.sh`. it's also the only file that you have to update in the future whenever the required xcode version changes.