### PR TITLE
dev.sh: fix reset && setup race condition

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -90,11 +90,9 @@ ___helium_reset() {
     "$_root_dir/devutils/update_patches.sh" unmerge || true
     rm "$_subs_cache" || true
     rm "$_namesubs_cache" || true
-
-    (
-        mv "$_src_dir" "${_src_dir}x" && \
-        rm -rf "${_src_dir}x"
-    ) &
+    if mv "$_src_dir" "${_src_dir}x"; then
+        rm -rf "${_src_dir}x" &
+    fi
 }
 
 ___helium_name_substitution() {


### PR DESCRIPTION
when running `he reset && he setup` there is a very high likelihood that it will fail, because src is not yet moved to srcx. make it blocking so that it happens before control is returned to shell prompt
