### PR TITLE
dev.sh: avoid system permission dialogs when running

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -147,7 +147,9 @@ ___helium_build() {
 ___helium_run() {
     cd "$_src_dir" && ./out/Default/Helium.app/Contents/MacOS/Helium \
     --user-data-dir="$HOME/Library/Application Support/net.imput.helium.dev" \
-    --enable-ui-devtools=$RANDOM
+    --enable-ui-devtools \
+    --use-mock-keychain \
+    --disable-features=DialMediaRouteProvider
 }
 
 ___helium_pull() {


### PR DESCRIPTION
`--use-mock-keychain` prevents keychain prompts
`--disable-features=DialMediaRouteProvider` prevents local network prompts

[chromium build guide](https://chromium.googlesource.com/chromium/src.git/+/HEAD/docs/mac_build_instructions.md#avoiding-system-permissions-dialogs-after-each-build) recommends using both of these for sake of convenience, and i agree