### PR TITLE
ci: use dispatch inputs directly, add option for builds without releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,13 @@ on:
     inputs:
       runner:
         required: false
-        description: 'Runner image name'
-        default: 'macos-latest'
+        description: "Runner image name"
+        default: "macos-latest"
+      do-release:
+        required: false
+        type: boolean
+        description: "Create a release after build is done"
+        default: false
 
 permissions:
   contents: write
@@ -28,6 +33,7 @@ jobs:
     needs: build
     name: Release macOS binaries of Helium
     runs-on: ${{ inputs.runner }}
+    if: ${{ inputs.do-release }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v4


### PR DESCRIPTION
basically a copy of imputnet/helium-linux#12 but for macos and with a bub fix for inputs