### PR TITLE
ci/prepare: lock python version to 3.13

### DIFF
--- a/.github/actions/prepare-environment/action.yml
+++ b/.github/actions/prepare-environment/action.yml
@@ -2,6 +2,10 @@ name: Prepare build environment
 runs:
   using: composite
   steps:
+    - name: Setup Python 3.13
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.13'
     - name: Copy GitHub specific scripts to git-root folder
       run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
       shell: bash


### PR DESCRIPTION
python 3.14 removed Str from the ast module, and the fix commit isn't in the current chromium version as of writing

hopefully fixes failing builds: https://github.com/imputnet/helium-macos/actions/runs/20778522881/job/59670092733#step:4:383