### PR TITLE
downloads-arm64: bump llvm to version used by chromium M144

### DIFF
--- a/downloads-arm64.ini
+++ b/downloads-arm64.ini
@@ -2,11 +2,11 @@
 
 # Pre-built LLVM toolchain for convenience
 [llvm]
-version = 4d4cb757f94470b95458fcbe3b88332b212feeee
+version = ea10026b64f66b3b69c0545db20f9daa8579f5cb
 url = https://github.com/dumbmoron/llvm-macos-buildbot/releases/download/%(version)s-arm64/clang+llvm-%(version)s-arm64-apple-darwin21.0.tar.xz
 download_filename = clang+llvm-%(version)s-arm64-apple-darwin21.0.tar.xz
 strip_leading_dirs = clang+llvm-%(version)s-arm64-apple-darwin21.0
-sha512 = 5ea4baa68d043f1ca3f3cce4e3ff5fea0022a54e7ae41b942e33682ac8e6e12e9afa8834ecedde1def464595922b8d58c30473af569ff205cb2d70cdefb87e8a
+sha512 = b58c4e760529e2c0fcfce5a47f240537169678bb37e0be342698c1d688cb22d22b6ade4d7a1397c3b89caf645a29d784ba9c1bc973b2e47d81e7de0206ac1125
 output_path = third_party/llvm-build/Release+Asserts
 
 [nodejs]


### PR DESCRIPTION
https://source.chromium.org/chromium/chromium/src/+/refs/tags/144.0.7559.59:tools/clang/scripts/update.py;bpv=1;bpt=0
