### PR TITLE
helium/updater: speculative fix for update/relaunch crash

### DIFF
--- a/patches/helium/macos/updater/maybe-fix-bundle-check-crash.patch
+++ b/patches/helium/macos/updater/maybe-fix-bundle-check-crash.patch
@@ -1,0 +1,38 @@
+--- a/chrome/app/chrome_main_mac.mm
++++ b/chrome/app/chrome_main_mac.mm
+@@ -104,10 +104,33 @@ NSBundle* OuterAppBundle() {
+ 
+ void SetUpBundleOverrides() {
+   @autoreleasepool {
+-    base::apple::SetOverrideFrameworkBundlePath(
+-        chrome::GetFrameworkBundlePath());
++    base::FilePath framework_path = chrome::GetFrameworkBundlePath();
++    NSBundle* framework_bundle = nil;
++
++    if (!framework_path.empty()) {
++      framework_bundle =
++        [NSBundle bundleWithURL:base::apple::FilePathToNSURL(framework_path)];
++    }
++
++    if (!framework_bundle) {
++      LOG(ERROR) << "no framework bundle found, falling back to BWI";
++      framework_bundle =
++        [NSBundle bundleWithIdentifier:@"net.imput.helium.framework"];
++    }
++
++    if (!framework_bundle) {
++      LOG(ERROR) << "still no framework bundle found! crashing";
++    }
++
++    CHECK(framework_bundle);
++    base::apple::SetOverrideFrameworkBundle(framework_bundle);
+ 
+     NSBundle* base_bundle = OuterAppBundle();
++    if (!base_bundle) {
++      LOG(ERROR) << "no base bundle found, falling back to BWI";
++      base_bundle = [NSBundle bundleWithIdentifier:@"net.imput.helium"];
++    }
++
+     base::apple::SetOverrideOuterBundle(base_bundle);
+     base::apple::SetBaseBundleIDOverride(
+         base::SysNSStringToUTF8(base_bundle.bundleIdentifier));

--- a/patches/series
+++ b/patches/series
@@ -15,3 +15,4 @@ rebel/macos/sparkle-integration.patch
 helium/macos/updater/fixup-sparkle-glue.patch
 helium/macos/updater/sparkle2-integration.patch
 helium/macos/updater/disable-default-updater.patch
+helium/macos/updater/maybe-fix-bundle-check-crash.patch


### PR DESCRIPTION
The crash happens in:
```
  Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
  0  base::apple::SetOverrideFrameworkBundlePath(...)   bundle_locations.mm:104
  1  SetUpBundleOverrides()                             chrome_main_mac.mm:107
  2  ChromeMain                                         chrome_main.cc:165
  3  main + 196
  4  dyld start + 7184
```

because this CHECK fails:
```
  NSBundle* bundle = [NSBundle bundleWithURL:apple::FilePathToNSURL(file_path)];
  CHECK(bundle) << "Failed to load the bundle at " << file_path.value();
```

I suspect this is because Sparkle extracts the new .app into a temporary dir and then swaps the old/new .app around. This causes `chrome::GetFrameworkBundlePath()` to return the wrong path, and in turn `bundleWithURL` fails. Let's try to use `bundleWithIdentifier:` instead to load the bundle if the usual path fails to load.

fixes (maybe) #127