### PR TITLE
dev & build: add CCACHE_COMPILERCHECK=content to ccache args

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -60,7 +60,7 @@ cat "$_main_repo/flags.gn" "$_root_dir/flags.macos.gn" > "$_src_dir/out/Default/
 if command -v sccache 2>&1 >/dev/null; then
   echo 'cc_wrapper="sccache"' >> "$_src_dir/out/Default/args.gn";
 elif command -v ccache 2>&1 >/dev/null; then
-  echo 'cc_wrapper="env CCACHE_SLOPPINESS=time_macros ccache"' >> "$_src_dir/out/Default/args.gn";
+  echo 'cc_wrapper="env CCACHE_COMPILERCHECK=content CCACHE_SLOPPINESS=time_macros ccache"' >> "$_src_dir/out/Default/args.gn";
 else
   echo 'warn: sccache or ccache is not available' >&2
 fi

--- a/dev.sh
+++ b/dev.sh
@@ -12,7 +12,7 @@ ___helium_setup_gn() {
     if command -v sccache 2>&1 >/dev/null; then
         echo 'cc_wrapper="sccache"' >> "$OUT_FILE"
     elif command -v ccache 2>&1 >/dev/null; then
-        echo 'cc_wrapper="env CCACHE_SLOPPINESS=time_macros ccache"' >> "$OUT_FILE"
+        echo 'cc_wrapper="env CCACHE_COMPILERCHECK=content CCACHE_SLOPPINESS=time_macros ccache"' >> "$OUT_FILE"
     else
         echo 'warn: sccache or ccache is not available' >&2
     fi


### PR DESCRIPTION
fixes cache skips caused by src dir re-init, cuz ccache now identifies the compiler by contents instead of modification time. mtime is reset by chromium toolchain's clang update script: https://source.chromium.org/chromium/chromium/src/+/refs/tags/147.0.7727.101:tools/clang/scripts/update.py;drc=6f920cff25ae8852f16c3bb71007b7a9aaebc497;l=200