### PR TITLE
helium/macos: add handler to open mac keyboard shortcut settings

### DIFF
--- a/patches/helium/macos/open-shortcuts-settings-action.patch
+++ b/patches/helium/macos/open-shortcuts-settings-action.patch
@@ -1,0 +1,71 @@
+Used by the keyboard shortcuts settings page to direct the user to macOS settings
+
+--- a/base/mac/mac_util.h
++++ b/base/mac/mac_util.h
+@@ -105,6 +105,9 @@ enum class SystemSettingsPane {
+   // Date & Time
+   kDateTime,
+ 
++  // Keyboard > Keyboard Shortcuts
++  kKeyboardShortcuts,
++
+   // Network > Proxies
+   kNetwork_Proxies,
+ 
+--- a/base/mac/mac_util.mm
++++ b/base/mac/mac_util.mm
+@@ -474,6 +474,17 @@ void OpenSystemSettingsPane(SystemSettin
+         pane_file = @"/System/Library/PreferencePanes/DateAndTime.prefPane";
+       }
+       break;
++    case SystemSettingsPane::kKeyboardShortcuts:
++      if (MacOSMajorVersion() >= 15) {
++        url = @"x-apple.systempreferences:com.apple.Keyboard?Shortcuts";
++      } else if (MacOSMajorVersion() >= 13) {
++        url = @"x-apple.systempreferences:com.apple.Keyboard-Settings."
++              @"extension?Shortcuts";
++      } else {
++        url = @"x-apple.systempreferences:com.apple.preference.keyboard?"
++              @"Shortcuts";
++      }
++      break;
+     case SystemSettingsPane::kNetwork_Proxies:
+       if (MacOSMajorVersion() >= 13) {
+         url = @"x-apple.systempreferences:com.apple.Network-Settings.extension?"
+--- a/chrome/browser/ui/webui/settings/mac_system_settings_handler.cc
++++ b/chrome/browser/ui/webui/settings/mac_system_settings_handler.cc
+@@ -15,12 +15,24 @@ MacSystemSettingsHandler::~MacSystemSett
+ 
+ void MacSystemSettingsHandler::RegisterMessages() {
+   web_ui()->RegisterMessageCallback(
++      "openKeyboardShortcutsSettings",
++      base::BindRepeating(
++          &MacSystemSettingsHandler::HandleOpenKeyboardShortcutsSettings,
++          base::Unretained(this)));
++  web_ui()->RegisterMessageCallback(
+       "openTrackpadGesturesSettings",
+       base::BindRepeating(
+           &MacSystemSettingsHandler::HandleOpenTrackpadGesturesSettings,
+           base::Unretained(this)));
+ }
+ 
++void MacSystemSettingsHandler::HandleOpenKeyboardShortcutsSettings(
++    const base::ListValue& args) {
++  AllowJavascript();
++  base::mac::OpenSystemSettingsPane(
++      base::mac::SystemSettingsPane::kKeyboardShortcuts);
++}
++
+ void MacSystemSettingsHandler::HandleOpenTrackpadGesturesSettings(
+     const base::ListValue& args) {
+   AllowJavascript();
+--- a/chrome/browser/ui/webui/settings/mac_system_settings_handler.h
++++ b/chrome/browser/ui/webui/settings/mac_system_settings_handler.h
+@@ -24,6 +24,7 @@ class MacSystemSettingsHandler : public
+   void OnJavascriptDisallowed() override {}
+ 
+  private:
++  void HandleOpenKeyboardShortcutsSettings(const base::ListValue& args);
+   void HandleOpenTrackpadGesturesSettings(const base::ListValue& args);
+ };
+ 

--- a/patches/series
+++ b/patches/series
@@ -16,3 +16,4 @@ helium/macos/updater/fixup-sparkle-glue.patch
 helium/macos/updater/sparkle2-integration.patch
 helium/macos/updater/disable-default-updater.patch
 helium/macos/applescript-tab-select-command.patch
+helium/macos/open-shortcuts-settings-action.patch


### PR DESCRIPTION
used/needed by https://github.com/imputnet/helium/pull/1552