### PR TITLE
flags: set v8_symbol_level to 0

### DIFF
--- a/flags.macos.gn
+++ b/flags.macos.gn
@@ -1,4 +1,5 @@
 blink_symbol_level=0
+v8_symbol_level=0
 enable_iterator_debugging=false
 enable_mse_mpeg2ts_stream_parser=true
 enable_rust=true


### PR DESCRIPTION
we don't modify or debug v8, so we don't need symbols for it. this change, most importantly, decreases memory pressure, which results in faster and more "convenient" builds in local dev env.

ref: https://www.chromium.org/developers/gn-build-configuration/#remove-v8-symbols