### PR TITLE
sparkle: update to 2.9.6, build and use BinaryDelta directly

### DIFF
--- a/.github/scripts/github_prep_sparkle_deltas.sh
+++ b/.github/scripts/github_prep_sparkle_deltas.sh
@@ -2,12 +2,10 @@
 set -ex
 
 pip3 install requests --break-system-packages
-brew install sparkle
-xattr -cr /opt/homebrew/Caskroom/sparkle/*/bin/BinaryDelta
-export PATH="$(echo /opt/homebrew/Caskroom/sparkle/*/bin):$PATH"
+export PATH="$PWD/build/src/out/Default:$PATH"
 
 python3 ./devutils/generate_sparkle_deltas.py "$@"
 
-echo 'deltas<<EOF' >> $GITHUB_OUTPUT
-find ./release_asset/ -name '*.delta' >> $GITHUB_OUTPUT
-echo EOF >> $GITHUB_OUTPUT
+echo 'deltas<<EOF' >> "$GITHUB_OUTPUT"
+find ./release_asset/ -name '*.delta' >> "$GITHUB_OUTPUT"
+echo EOF >> "$GITHUB_OUTPUT"

--- a/downloads.ini
+++ b/downloads.ini
@@ -1,7 +1,7 @@
 [sparkle]
-version = 2.9.2
+version = 2.9.6
 url = https://github.com/sparkle-project/Sparkle/archive/refs/tags/%(version)s.tar.gz
-sha512 = a52c3ce998c48b70bf704270f0adf0b7fb523ad2e31bac59dcf34ea7a934d7d95c3ae7f551d7d92f8466fc36856e5408b01e35e5e48217e26480d4669e17f9af
+sha512 = 76c20dd572bdd28baf8de47beaf672668c9c449811950aac19c555530e2a7713fff2afdaa3a3e033b60a2227eff2483130b04c5a11c3526a8105f6d77162eddf
 strip_leading_dirs = Sparkle-%(version)s
 download_filename = sparkle-v%(version)s.tar.gz
 output_path = third_party/sparkle

--- a/patches/helium/macos/updater/fixup-sparkle-glue.patch
+++ b/patches/helium/macos/updater/fixup-sparkle-glue.patch
@@ -746,16 +746,21 @@
  # Copyright 2023 Viasat Inc. All rights reserved.
  # Use of this source code is governed by a BSD-style license that can be
  # found in the header of the corresponding patch.
-@@ -16,7 +20,7 @@ bundle_data("sparkle_framework") {
+@@ -16,8 +20,11 @@ bundle_data("sparkle_framework") {
  action("build_sparkle_framework") {
    script = "build_sparkle_framework.py"
  
 -  sources = [ "src/REVISION" ]
+-  outputs = [ "$root_out_dir/Sparkle.framework" ]
 +  sources = [ "Package.swift" ]
-   outputs = [ "$root_out_dir/Sparkle.framework" ]
++  outputs = [
++    "$root_out_dir/BinaryDelta",
++    "$root_out_dir/Sparkle.framework",
++  ]
  }
  
-@@ -29,6 +33,7 @@ config("sparkle_link_test") {
+ config("sparkle_link_test") {
+@@ -29,6 +36,7 @@ config("sparkle_link_test") {
      "-framework",
      "Sparkle",
    ]
@@ -763,7 +768,7 @@
  }
  
  config("sparkle_link_framework") {
-@@ -40,4 +45,5 @@ config("sparkle_link_framework") {
+@@ -40,4 +48,5 @@ config("sparkle_link_framework") {
      "-framework",
      "Sparkle",
    ]
@@ -788,11 +793,11 @@
  
  # In-order targets to build
 -TARGETS = ['bsdiff', 'ed25519', 'Sparkle']
-+TARGETS = ['Sparkle']
++TARGETS = ['Sparkle', 'BinaryDelta']
  
  class ChangeDirectory(object):
    """
-@@ -27,26 +32,37 @@ class ChangeDirectory(object):
+@@ -27,26 +32,38 @@ class ChangeDirectory(object):
  def main(args):
    build_dir = 'CONFIGURATION_BUILD_DIR=' + os.getcwd()
  
@@ -814,6 +819,7 @@
          'Release',
          build_dir,
 +        'PROJECT_TEMP_DIR=' + temp_dir,
++        'SYMROOT=' + temp_dir,
 +        'SPARKLE_BUILD_UI_BITS=0',
 +        'SPARKLE_BUILD_LEGACY_DSA_SUPPORT=0',
 +        'SPARKLE_BUILD_LEGACY_SUUPDATER=0',

--- a/patches/helium/macos/updater/sparkle2-integration.patch
+++ b/patches/helium/macos/updater/sparkle2-integration.patch
@@ -189,7 +189,7 @@
      allow_circular_includes_from += [
 --- a/third_party/sparkle/Sparkle.xcodeproj/project.pbxproj
 +++ b/third_party/sparkle/Sparkle.xcodeproj/project.pbxproj
-@@ -464,6 +464,8 @@
+@@ -465,6 +465,8 @@
  		72F9EC441D5E9ED8004AC8B6 /* SPUDownloadData.h in Headers */ = {isa = PBXBuildFile; fileRef = 72F9EC421D5E9ED8004AC8B6 /* SPUDownloadData.h */; settings = {ATTRIBUTES = (Public, ); }; };
  		72F9EC451D5E9ED8004AC8B6 /* SPUDownloadData.m in Sources */ = {isa = PBXBuildFile; fileRef = 72F9EC431D5E9ED8004AC8B6 /* SPUDownloadData.m */; };
  		72F9EC481D5EA904004AC8B6 /* SPUUpdaterDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 72F9EC471D5EA7D3004AC8B6 /* SPUUpdaterDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -198,7 +198,7 @@
  		72FE54422E56A14100227A91 /* SUUpdateAlert.xib in Resources */ = {isa = PBXBuildFile; fileRef = 72FE54412E56A14100227A91 /* SUUpdateAlert.xib */; };
  		C23E885B1BE7B24F0050BB73 /* SparkleTestCodeSignApp.enc.dmg in Resources */ = {isa = PBXBuildFile; fileRef = C23E88591BE7AF890050BB73 /* SparkleTestCodeSignApp.enc.dmg */; };
  		EA1E281722B645AE004AA304 /* libbsdiff.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA1E280F22B64522004AA304 /* libbsdiff.a */; };
-@@ -1400,9 +1402,11 @@
+@@ -1402,9 +1404,11 @@
  		72F9EC421D5E9ED8004AC8B6 /* SPUDownloadData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPUDownloadData.h; sourceTree = "<group>"; };
  		72F9EC431D5E9ED8004AC8B6 /* SPUDownloadData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPUDownloadData.m; sourceTree = "<group>"; };
  		72F9EC471D5EA7D3004AC8B6 /* SPUUpdaterDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPUUpdaterDelegate.h; sourceTree = "<group>"; };
@@ -210,7 +210,7 @@
  		A5BF4F1B1BC7668B007A052A /* SUTestWebServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUTestWebServer.h; sourceTree = "<group>"; };
  		A5BF4F1C1BC7668B007A052A /* SUTestWebServer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUTestWebServer.m; sourceTree = "<group>"; };
  		C23E88591BE7AF890050BB73 /* SparkleTestCodeSignApp.enc.dmg */ = {isa = PBXFileReference; lastKnownFileType = file; path = SparkleTestCodeSignApp.enc.dmg; sourceTree = "<group>"; };
-@@ -2239,6 +2243,8 @@
+@@ -2242,6 +2246,8 @@
  				7269E49C2648FC6C0088C213 /* SPUUserUpdateState+Private.h */,
  				7269E4992648F7C00088C213 /* SPUUserUpdateState.m */,
  				725CB9561C7120410064365A /* SPUUserDriver.h */,
@@ -219,7 +219,7 @@
  			);
  			name = "User Driver";
  			sourceTree = "<group>";
-@@ -2578,6 +2584,7 @@
+@@ -2581,6 +2587,7 @@
  				3772FEA913DE0B6B00F79537 /* SUVersionDisplayProtocol.h in Headers */,
  				724BB3871D32A167005D534A /* SUXPCInstallerConnection.h in Headers */,
  				724BB3A81D33461B005D534A /* SUXPCInstallerStatus.h in Headers */,
@@ -227,7 +227,7 @@
  			);
  			runOnlyForDeploymentPostprocessing = 0;
  		};
-@@ -3664,6 +3671,7 @@
+@@ -3668,6 +3675,7 @@
  				724BB3881D32A167005D534A /* SUXPCInstallerConnection.m in Sources */,
  				724BB3A91D33461B005D534A /* SUXPCInstallerStatus.m in Sources */,
  				723AC011259DBDAA00BDB4FA /* SUReleaseNotesCommon.m in Sources */,


### PR DESCRIPTION
sparkle cask is no longer available on homebrew, this fixes delta creation in release CI