### PR TITLE
helium/macos: prevent data reset on temporary keychain issues

### DIFF
--- a/patches/helium/macos/prevent-reset-on-keychain-unavailability.patch
+++ b/patches/helium/macos/prevent-reset-on-keychain-unavailability.patch
@@ -1,0 +1,282 @@
+--- a/components/os_crypt/common/keychain_password_mac.h
++++ b/components/os_crypt/common/keychain_password_mac.h
+@@ -5,9 +5,12 @@
+ #ifndef COMPONENTS_OS_CRYPT_COMMON_KEYCHAIN_PASSWORD_MAC_H_
+ #define COMPONENTS_OS_CRYPT_COMMON_KEYCHAIN_PASSWORD_MAC_H_
+ 
++#include <Security/Security.h>
++
+ #include <string>
+ 
+ #include "base/memory/raw_ref.h"
++#include "base/types/expected.h"
+ 
+ namespace crypto::apple {
+ class KeychainV2;
+@@ -36,6 +39,10 @@ class KeychainPassword {
+   // empty string is returned.
+   std::string GetPassword() const;
+ 
++  // As above, but preserves the Keychain error when access fails.
++  // The caller needs to distinguish denied access from errors it can retry.
++  base::expected<std::string, OSStatus> GetPasswordWithError() const;
++
+   // The service and account names used in Chrome's Safe Storage keychain item.
+   static KeychainNameType& GetServiceName();
+   static KeychainNameType& GetAccountName();
+--- a/components/os_crypt/common/keychain_password_mac.mm
++++ b/components/os_crypt/common/keychain_password_mac.mm
+@@ -121,6 +121,11 @@ KeychainPassword::KeychainPassword(Keych
+ KeychainPassword::~KeychainPassword() = default;
+ 
+ std::string KeychainPassword::GetPassword() const {
++  return GetPasswordWithError().value_or(std::string());
++}
++
++base::expected<std::string, OSStatus>
++KeychainPassword::GetPasswordWithError() const {
+   auto password =
+       GetPasswordImpl(*keychain_, GetServiceName(), GetAccountName());
+ 
+@@ -133,5 +138,5 @@ std::string KeychainPassword::GetPasswor
+                              previous_error);
+   }
+ 
+-  return password.value_or(std::string());
++  return password;
+ }
+--- a/components/os_crypt/async/browser/keychain_key_provider.h
++++ b/components/os_crypt/async/browser/keychain_key_provider.h
+@@ -5,8 +5,12 @@
+ #ifndef COMPONENTS_OS_CRYPT_ASYNC_BROWSER_KEYCHAIN_KEY_PROVIDER_H_
+ #define COMPONENTS_OS_CRYPT_ASYNC_BROWSER_KEYCHAIN_KEY_PROVIDER_H_
+ 
++#include <Security/Security.h>
++
++#include "base/functional/callback.h"
+ #include "base/gtest_prod_util.h"
+ #include "base/memory/raw_ptr.h"
++#include "base/memory/weak_ptr.h"
+ #include "base/types/expected.h"
+ #include "components/os_crypt/async/browser/key_provider.h"
+ 
+@@ -22,6 +26,13 @@ class COMPONENT_EXPORT(OS_CRYPT_ASYNC) K
+     : public KeyProvider {
+  public:
+   KeychainKeyProvider();
++
++  // Retries failed reads before invoking `on_failure` once on the calling
++  // sequence.
++  // On failure, key initialization remains pending so consumers cannot discard
++  // data that they cannot decrypt. The caller must handle the startup failure.
++  explicit KeychainKeyProvider(base::OnceClosure on_failure);
++
+   KeychainKeyProvider(const KeychainKeyProvider&) = delete;
+   KeychainKeyProvider& operator=(const KeychainKeyProvider&) = delete;
+   ~KeychainKeyProvider() override;
+@@ -40,7 +51,16 @@ class COMPONENT_EXPORT(OS_CRYPT_ASYNC) K
+   void GetKey(KeyCallback callback) override;
+   bool UseForEncryption() override;
+ 
++  void GetKeyWithRetries(KeyCallback callback, int retries_remaining);
++  void OnKeyReceived(KeyCallback callback,
++                     int retries_remaining,
++                     base::expected<Encryptor::Key, OSStatus> key);
++
+   raw_ptr<crypto::apple::KeychainV2> keychain_for_testing_ = nullptr;
++  // Keep the failure policy after the one-shot notification is consumed.
++  const bool fail_closed_on_error_ = false;
++  base::OnceClosure on_failure_;
++  base::WeakPtrFactory<KeychainKeyProvider> weak_factory_{this};
+ };
+ 
+ }  // namespace os_crypt_async
+--- a/components/os_crypt/async/browser/keychain_key_provider.mm
++++ b/components/os_crypt/async/browser/keychain_key_provider.mm
+@@ -6,11 +6,15 @@
+ 
+ #include <array>
+ #include <memory>
++#include <utility>
+ 
+ #include "base/apple/osstatus_logging.h"
+ #include "base/command_line.h"
+ #include "base/functional/bind.h"
++#include "base/location.h"
++#include "base/task/sequenced_task_runner.h"
+ #include "base/task/thread_pool.h"
++#include "base/time/time.h"
+ #include "base/types/expected.h"
+ #include "components/os_crypt/async/common/algorithm.mojom.h"
+ #include "components/os_crypt/common/keychain_password_mac.h"
+@@ -31,8 +35,11 @@ constexpr auto kSalt =
+     std::to_array<uint8_t>({'s', 'a', 'l', 't', 'y', 's', 'a', 'l', 't'});
+ constexpr size_t kIterations = 1003;
+ 
++constexpr int kMaxKeychainRetries = 3;
++constexpr base::TimeDelta kKeychainRetryDelay = base::Seconds(1);
++
+ // This function runs on a worker thread and performs blocking Keychain IO.
+-base::expected<Encryptor::Key, KeyProvider::KeyError> GetKeyTask(
++base::expected<Encryptor::Key, OSStatus> GetKeyTask(
+     crypto::SubtlePassKey subtle_passkey,
+     crypto::apple::KeychainV2* keychain_for_testing) {
+   std::unique_ptr<crypto::apple::FakeKeychainV2> scoped_fake_keychain;
+@@ -49,17 +56,18 @@ base::expected<Encryptor::Key, KeyProvid
+   }
+ 
+   KeychainPassword keychain_password(*keychain_to_use);
+-  std::string password = keychain_password.GetPassword();
+-
+-  // `password` can be an empty string if keychain access is denied by the user
+-  // or some other error occurs.
+-  if (password.empty()) {
+-    return base::unexpected(KeyProvider::KeyError::kTemporarilyUnavailable);
++  auto password = keychain_password.GetPasswordWithError();
++  if (!password.has_value()) {
++    return base::unexpected(password.error());
++  }
++  if (password->empty()) {
++    return base::unexpected(errSecDecode);
+   }
+ 
++  // Derive the key here so the Keychain secret stays local to this worker task.
+   std::array<uint8_t, kDerivedKeySize> key_bytes;
+   crypto::kdf::Pbkdf2HmacSha1({.iterations = kIterations},
+-                              base::as_byte_span(password), kSalt, key_bytes,
++                              base::as_byte_span(*password), kSalt, key_bytes,
+                               subtle_passkey);
+ 
+   return Encryptor::Key(key_bytes, mojom::Algorithm::kAES128CBC);
+@@ -69,6 +77,9 @@ base::expected<Encryptor::Key, KeyProvid
+ 
+ KeychainKeyProvider::KeychainKeyProvider() = default;
+ 
++KeychainKeyProvider::KeychainKeyProvider(base::OnceClosure on_failure)
++    : fail_closed_on_error_(true), on_failure_(std::move(on_failure)) {}
++
+ KeychainKeyProvider::KeychainKeyProvider(
+     crypto::apple::KeychainV2* keychain_for_testing)
+     : keychain_for_testing_(keychain_for_testing) {}
+@@ -76,6 +87,11 @@ KeychainKeyProvider::KeychainKeyProvider
+ KeychainKeyProvider::~KeychainKeyProvider() = default;
+ 
+ void KeychainKeyProvider::GetKey(KeyCallback callback) {
++  GetKeyWithRetries(std::move(callback), kMaxKeychainRetries);
++}
++
++void KeychainKeyProvider::GetKeyWithRetries(KeyCallback callback,
++                                          int retries_remaining) {
+   // Apple's documentation [1] recommends accessing the keychain on a worker
+   // thread. [1]
+   // https://developer.apple.com/documentation/security/secitemcopymatching%28_%3A_%3A%29#Performance-considerations
+@@ -83,7 +99,45 @@ void KeychainKeyProvider::GetKey(KeyCall
+       FROM_HERE, {base::TaskPriority::USER_BLOCKING, base::MayBlock()},
+       base::BindOnce(&GetKeyTask, crypto::SubtlePassKey{},
+                      keychain_for_testing_),
+-      base::BindOnce(std::move(callback), kKeyTag));
++      base::BindOnce(&KeychainKeyProvider::OnKeyReceived,
++                     weak_factory_.GetWeakPtr(), std::move(callback),
++                     retries_remaining));
++}
++
++void KeychainKeyProvider::OnKeyReceived(
++    KeyCallback callback,
++    int retries_remaining,
++    base::expected<Encryptor::Key, OSStatus> key) {
++  if (key.has_value()) {
++    std::move(callback).Run(kKeyTag, std::move(*key));
++    return;
++  }
++
++  if (!fail_closed_on_error_) {
++    std::move(callback).Run(
++        kKeyTag, base::unexpected(KeyError::kTemporarilyUnavailable));
++    return;
++  }
++
++  // Give Keychain errors a few chances to clear while data loading stays paused.
++  // Do not repeat an authentication prompt after access was denied or canceled.
++  if (retries_remaining > 0 && key.error() != errSecAuthFailed &&
++      key.error() != errSecUserCanceled) {
++    base::SequencedTaskRunner::GetCurrentDefault()->PostDelayedTask(
++        FROM_HERE,
++        base::BindOnce(&KeychainKeyProvider::GetKeyWithRetries,
++                       weak_factory_.GetWeakPtr(), std::move(callback),
++                       retries_remaining - 1),
++        kKeychainRetryDelay);
++    return;
++  }
++
++  // Deliberately do not run the key callback: that would let data loading proceed
++  // without a key and could delete cookies or reset protected preferences.
++  // Keep it waiting while the browser shows the error and exits.
++  if (on_failure_) {
++    std::move(on_failure_).Run();
++  }
+ }
+ 
+ bool KeychainKeyProvider::UseForEncryption() {
+--- a/chrome/app/generated_resources.grd
++++ b/chrome/app/generated_resources.grd
+@@ -11874,6 +11874,9 @@ Check your passwords anytime in <ph name
+       </if> <!-- not is_android -->
+ 
+       <if expr="is_macosx">
++        <message name="IDS_KEYCHAIN_STARTUP_ERROR" desc="Startup error shown when the browser cannot access its macOS Keychain encryption key.">
++          Helium couldn't access the macOS Keychain. To protect your data, the browser will close. If prompted by macOS, allow access to Helium's encryption key. Quit any other copies of Helium, then reopen it.
++        </message>
+         <!-- Confirm to quit panel -->
+         <message name="IDS_CONFIRM_TO_QUIT_DESCRIPTION" desc="Instructions for how the user should confirm quitting.">
+           Hold <ph name="KEY_EQUIVALENT">$1<ex>⌘Q</ex></ph> to Quit
+--- a/chrome/browser/browser_process_impl.cc
++++ b/chrome/browser/browser_process_impl.cc
+@@ -283,6 +283,11 @@ void OnLocalStatePrefsLoaded();
+ #endif
+ 
+ #if BUILDFLAG(IS_MAC)
++#include <stdlib.h>
++
++#include "base/process/process.h"
++#include "chrome/browser/ui/simple_message_box.h"
++#include "chrome/grit/generated_resources.h"
+ #include "components/os_crypt/async/browser/keychain_key_provider.h"
+ #endif
+ 
+@@ -309,6 +314,23 @@ static constexpr base::TimeDelta kEndSes
+ using content::BrowserThread;
+ using content::ChildProcessSecurityPolicy;
+ 
++#if BUILDFLAG(IS_MAC)
++namespace {
++
++void ShowKeychainStartupError() {
++  chrome::ShowWarningMessageBoxAsync(
++      gfx::NativeWindow(), l10n_util::GetStringUTF16(IDS_PRODUCT_NAME),
++      l10n_util::GetStringUTF16(IDS_KEYCHAIN_STARTUP_ERROR),
++      base::BindOnce([](chrome::MessageBoxResult) {
++        // Profile initialization is still waiting for the key.
++        // Exit without flushing partially initialized preferences.
++        base::Process::TerminateCurrentProcessImmediately(EXIT_FAILURE);
++      }));
++}
++
++}  // namespace
++#endif  // BUILDFLAG(IS_MAC)
++
+ BrowserProcessImpl::BrowserProcessImpl(StartupData* startup_data)
+     : startup_data_(startup_data),
+       browser_policy_connector_(startup_data->chrome_feature_list_creator()
+@@ -1615,9 +1637,10 @@ void BrowserProcessImpl::PreMainMessageL
+ 
+ #if BUILDFLAG(IS_MAC)
+   if (base::FeatureList::IsEnabled(features::kUseKeychainKeyProvider)) {
+-    providers.emplace_back(std::make_pair(
++    providers.emplace_back(
+         /*precedence=*/10u,
+-        std::make_unique<os_crypt_async::KeychainKeyProvider>()));
++        std::make_unique<os_crypt_async::KeychainKeyProvider>(
++            base::BindOnce(&ShowKeychainStartupError)));
+   }
+ #endif  // BUILDFLAG(IS_MAC)
+ 

--- a/patches/series
+++ b/patches/series
@@ -19,3 +19,4 @@ helium/macos/applescript-tab-select-command.patch
 helium/macos/open-shortcuts-settings-action.patch
 
 helium/macos/native-translation-context-option.patch
+helium/macos/prevent-reset-on-keychain-unavailability.patch


### PR DESCRIPTION
if the macOS Keychain is temporarily unavailable during startup, chromium can fail to decrypt protected data. this can cause data loss, including deleted cookies, extension resets, and search engine resets.

this patch adds 3 retries for temporary Keychain failures before allowing startup to continue. if the data encryption key still can't be retrieved, we show a blocking warning and close Helium before the failure can cause a reset.

once Keychain access is restored, via a system dialog or other means, the user can reopen Helium without losing data due to the failed startup