### PR TITLE
ci/sanity: cache sources and simplify sanity checks

### DIFF
--- a/.github/scripts/sanity-check.sh
+++ b/.github/scripts/sanity-check.sh
@@ -1,41 +1,56 @@
 #!/bin/bash
 set -exo pipefail
 
-sudo mdutil -a -i off
-
-brew install ninja coreutils python@3.14 quilt llvm@20 --overwrite
-brew unlink python || true
-brew link python@3.14 llvm@20 --force
-
-pip3.14 install httplib2==0.22.0 requests Pillow --break
-
 source dev.sh
 
 export QUILT_PATCHES="$PWD/patches"
 export QUILT_SERIES="series.merged"
 
-he reset
-he setup | tee setup.log
+_check="${1:-sanity}"
+_source_archive="$_root_dir/build/chromium-source.tar"
 
-if [ "$1" = "sub" ]; then
-    he sub
+mkdir -p "$_src_dir" "$_download_cache"
+if [ -f "$_source_archive" ]; then
+    tar -xf "$_source_archive" -C "$_src_dir"
+else
+    "$_root_dir/retrieve_and_unpack_resource.sh" -d -g || \
+        "$_root_dir/retrieve_and_unpack_resource.sh" -g
+    python3 "$_main_repo/utils/prune_binaries.py" "$_src_dir" "$_main_repo/pruning.list"
 
-    cd "$_src_dir"
-    cat components/omnibox_strings.grdp | grep -q Helium
+    # Keep the cached archive unpatched, without clone history or staging files.
+    tar -cf "$_source_archive" --exclude=.git --exclude=./uc_staging -C "$_src_dir" .
+fi
+
+if [ "$_check" = "sanity" ]; then
+    mkdir -p "$_out_dir"
+    ___helium_toolchain
+    ___helium_setup_gn
+fi
+
+he resources
+python3 "$_main_repo/utils/helium_version.py" \
+    --tree "$_main_repo" --platform-tree "$_root_dir" --chromium-tree "$_src_dir"
+he merge
+he push | tee setup.log
+
+if [ "$_check" = "substitution" ]; then
+    python3 "$_main_repo/utils/name_substitution.py" --sub -t "$_src_dir"
+    python3 "$_main_repo/utils/domain_substitution.py" apply \
+        -r "$_main_repo/domain_regex.list" \
+        -f "$_main_repo/domain_substitution.list" "$_src_dir"
+
+    grep -q Helium "$_src_dir/components/omnibox_strings.grdp"
     exit 0
 fi
 
-set +e
 if grep -q 'offset .* lines' setup.log; then
     grep -A20 -B20 'offset .* lines' setup.log >&2
     exit 1
 fi
 
-cd "$_src_dir"
-timeout 30 ninja -C out/Default chrome chromedriver
-_status_code=$?
+he configure
 
-if [ $_status_code != 124 ]; then
-    echo "failed with status code $_status_code" >&2
-    exit 1
-fi
+cd "$_src_dir"
+_status_code=0
+timeout 30 ninja -C out/Default chrome chromedriver || _status_code=$?
+test "$_status_code" -eq 124

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -6,21 +6,47 @@ permissions:
   contents: read
 
 jobs:
-  sanity:
+  check:
+    name: ${{ matrix.check }}
     runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        check: [sanity, substitution]
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: ./.github/actions/prepare-environment
-    - name: Run sanity check
-      run: ./sanity-check.sh
-  substitution:
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v6
       with:
-        submodules: true
-    - uses: ./.github/actions/prepare-environment
-    - name: Run substitution check
-      run: ./sanity-check.sh sub
+        python-version: '3.14'
+    - name: Prepare check environment
+      run: |
+        cp -a .github/scripts/. .
+        sudo mdutil -a -i off
+        brew install coreutils quilt --overwrite
+        python3 -m pip install httplib2==0.22.0 requests Pillow
+    - name: Cache Chromium source
+      uses: actions/cache@v5
+      with:
+        path: build/chromium-source.tar
+        key: >-
+          chromium-source-v1-${{ runner.os }}-${{ runner.arch }}-${{
+            hashFiles(
+              'helium-chromium/chromium_version.txt',
+              'helium-chromium/*.ini',
+              'helium-chromium/pruning.list',
+              'helium-chromium/utils/**',
+              'downloads.ini',
+              'retrieve_and_unpack_resource.sh',
+              '.github/scripts/sanity-check.sh'
+            )
+          }}
+    - name: Prepare build tools
+      if: matrix.check == 'sanity'
+      run: |
+        ./github_prepare_xcode.sh
+        brew install ninja llvm@20 --overwrite
+        brew link llvm@20 --force
+    - name: Run check
+      run: ./sanity-check.sh '${{ matrix.check }}'


### PR DESCRIPTION
cache pruned chromium sources before applying patches or substitutions, excluding git history and staging files.

skip xcode, toolchain downloads, gn setup, and substitution backups in the substitution job. share workflow setup through a job matrix.
