### PR TITLE
helium/macos/sparkle: don't bundle sparkle into aperitif helpers

### DIFF
--- a/patches/helium/macos/updater/sparkle2-integration.patch
+++ b/patches/helium/macos/updater/sparkle2-integration.patch
@@ -454,7 +454,7 @@
 +      ]
 +
 +      deps += [
-+        "//third_party/sparkle:sparkle_framework",
++        "//third_party/sparkle:build_sparkle_framework",
 +        "//components/helium_services",
 +      ]
 +      frameworks += [ "Sparkle.framework" ]


### PR DESCRIPTION
sparkle_framework bundle_data was a plain dep of //chrome/browser:core, so the aperitif helpers, which link via chrome_framework+link_nested, collected it and got their own unsigned copies of Sparkle.framework. this caused notarization to fail.

now we depend on the build_sparkle_framework action instead so only the framework's bundle_deps embeds sparkle.